### PR TITLE
Remove SSESpecification property in table definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,6 +248,9 @@ class ServerlessDynamodbLocal {
             if (migration.Tags) {
               delete migration.Tags;
             }
+            if (migration.SSESpecification) {
+              delete migration.SSESpecification;
+            }
             dynamodb.raw.createTable(migration, (err) => {
                 if (err) {
                     if (err.name === 'ResourceInUseException') {


### PR DESCRIPTION
Fixes issue where `serverless offline start` will return the following error, if `SSESpecification` is defined in the table definition.

```
Serverless: Watching for changes...
Serverless: DynamoDB - Error -

  Unexpected Parameter -----------------------------------

  Unexpected key 'SSESpecification' found in params

     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Forums:        forum.serverless.com
     Chat:          gitter.im/serverless/serverless

  Your Environment Information -----------------------------
     OS:                     darwin
     Node Version:           8.6.0
     Serverless Version:     1.26.0
```
